### PR TITLE
remove deadlock

### DIFF
--- a/pbft/network/proxy_server.go
+++ b/pbft/network/proxy_server.go
@@ -95,5 +95,5 @@ func (server *Server) getReply(writer http.ResponseWriter, request *http.Request
 
 func send(url string, msg []byte) {
 	buff := bytes.NewBuffer(msg)
-	http.Post("http://" + url, "application/json", buff)
+	go http.Post("http://" + url, "application/json", buff)
 }


### PR DESCRIPTION
Because of unpredictable network connections during consensus, a deadlock can be caused as below.

At `simple_pbft/pbft/network/proxy_server.go`

```go
func send(url string, msg []byte) {
	buff := bytes.NewBuffer(msg)
	http.Post("http://"+url, "application/json", buff)
}
```

`http.Post` will always wait until its response arrives. While `http.Post` is waiting, `node.MsgDelivery` is blocked so that `resolveMsg()` at `simple_pbft/pbft/network/node.go` can't deliver other msg. But the premise of the `http.Post` response’s arrival is that our node has processed the request msg of other nodes, so a deadlock is produced.

To resolve the deadlock, we can use go routine to make node processes other msg while waiting the post response.

```go
func send(url string, msg []byte) {
	buff := bytes.NewBuffer(msg)
	go http.Post("http://"+url, "application/json", buff)
}
```


